### PR TITLE
Fix project path usage

### DIFF
--- a/macro_manager/db.py
+++ b/macro_manager/db.py
@@ -2,7 +2,9 @@ from pathlib import Path
 import yaml
 from .models import Food
 
-DATA_DIR = Path("data")
+# Base directory of the project
+BASE_DIR = Path(__file__).resolve().parents[1]
+DATA_DIR = BASE_DIR / "data"
 FOODS_YAML = DATA_DIR / "foods.yaml"
 
 

--- a/run.bat
+++ b/run.bat
@@ -3,23 +3,8 @@
 :: 1.  Jump to the folder this script lives in
 cd /d "%~dp0"
 
-:: 2.  Pick the first interpreter that exists
-set "P313=%LocalAppData%\Programs\Python\Python313\python.exe"
-set "P311=%LocalAppData%\Programs\Python\Python311\python.exe"
-
-if exist "%P313%" (
-    "%P313%" -m streamlit run app.py --server.headless true %*
-    goto :done
-)
-
-if exist "%P311%" (
-    "%P311%" -m streamlit run app.py --server.headless true %*
-    goto :done
-)
-
-:: Fallback: rely on the launcher if you ever shuffle folders
-py -3.13 -m streamlit run app.py --server.headless true %*
-if %errorlevel% neq 0 py -3.11 -m streamlit run app.py --server.headless true %*
+:: 2.  Use the interpreter on PATH
+python -m streamlit run app.py --server.headless true %*
 
 :done
 echo --------------------------------------------------


### PR DESCRIPTION
## Summary
- use project-relative data directory
- simplify `run.bat` python invocation

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'yaml')*

------
https://chatgpt.com/codex/tasks/task_e_684100d9873c8333a23367d52f794db2