### PR TITLE
Improve CLI for Streamlit

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,9 +17,14 @@ pip install -e .
 Newer Python versions may fail to install due to upstream dependencies.
 
 ## Usage
+After installing in editable mode, launch the dashboard with the convenience
+command:
+
 ```bash
-python -m macro_manager
+macro-manager
 ```
+
+The same behaviour is available via `python -m macro_manager` if you prefer.
 
 ## License
 This project is licensed under the MIT License. See `LICENSE` for details.

--- a/macro_manager/__main__.py
+++ b/macro_manager/__main__.py
@@ -1,4 +1,30 @@
-from .app import main
+"""Entry point for ``python -m macro_manager`` and ``macro-manager`` CLI.
+
+This wrapper launches Streamlit with the bundled ``app.py`` so that the
+application runs with full Streamlit context (no ``ScriptRunContext``
+warnings). Additional command-line arguments are forwarded to Streamlit.
+"""
+
+from pathlib import Path
+import subprocess
+import sys
+
+
+def main() -> None:
+    """Execute ``streamlit run`` for the packaged application."""
+    app_path = Path(__file__).with_name("app.py")
+    cmd = [
+        sys.executable,
+        "-m",
+        "streamlit",
+        "run",
+        str(app_path),
+        "--server.headless",
+        "true",
+        *sys.argv[1:],
+    ]
+    subprocess.call(cmd)
+
 
 if __name__ == "__main__":
     main()

--- a/macro_manager/run.bat
+++ b/macro_manager/run.bat
@@ -8,18 +8,18 @@ set "P313=%LocalAppData%\Programs\Python\Python313\python.exe"
 set "P311=%LocalAppData%\Programs\Python\Python311\python.exe"
 
 if exist "%P313%" (
-    "%P313%" -m streamlit run app.py --server.headless true %*
+    "%P313%" -m macro_manager %*
     goto :done
 )
 
 if exist "%P311%" (
-    "%P311%" -m streamlit run app.py --server.headless true %*
+    "%P311%" -m macro_manager %*
     goto :done
 )
 
 :: Fallback: rely on the launcher if you ever shuffle folders
-py -3.13 -m streamlit run app.py --server.headless true %*
-if %errorlevel% neq 0 py -3.11 -m streamlit run app.py --server.headless true %*
+py -3.13 -m macro_manager %*
+if %errorlevel% neq 0 py -3.11 -m macro_manager %*
 
 :done
 echo --------------------------------------------------

--- a/run.bat
+++ b/run.bat
@@ -4,7 +4,7 @@
 cd /d "%~dp0"
 
 :: 2.  Use the interpreter on PATH
-python -m streamlit run app.py --server.headless true %*
+python -m macro_manager %*
 
 :done
 echo --------------------------------------------------

--- a/setup.py
+++ b/setup.py
@@ -14,7 +14,7 @@ setup(
     ],
     entry_points={
         "console_scripts": [
-            "macro-manager=macro_manager.app:main",
+            "macro-manager=macro_manager.__main__:main",
         ]
     },
     include_package_data=True,


### PR DESCRIPTION
## Summary
- run Streamlit via the module's main entry point
- point console entrypoint at the new __main__ module
- update Windows launch scripts to call `python -m macro_manager`
- document the `macro-manager` command in the README

## Testing
- `pip install -q -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68411998103883338c0a9ea41385b4b9