### PR TITLE
Add logging button and trends view

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,8 @@ A Streamlit application to visualize and log your daily macronutrient intake.
 ## Features
 - Dynamic food database driven by `data/foods.yaml`
 - Interactive dashboard with transparent background
-- Exportable PNG and CSV log of daily intake
+- Manually save your daily intake to a CSV log (one entry per day)
+- "Trends" tab to visualize macros over time
 
 ## Installation
 This project requires **Python 3.10–3.11**. Install the latest


### PR DESCRIPTION
## Summary
- let `save_dashboard` record meal description to log
- show dashboard/trends tabs in Streamlit app
- allow saving to log via a button
- document new features in README

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6848e297e9008333a202b4b0fab607f4