### PR TITLE
Fix transparent background for macro dashboard figure

### DIFF
--- a/macro_manager/plot.py
+++ b/macro_manager/plot.py
@@ -132,6 +132,7 @@ def build_dashboard_figure(meal: Meal):
     pct = {k: (totals[k]*4 if k != 'fat' else totals[k]*9) / kcal * 100 for k in ('protein', 'fat', 'carb')}
 
     fig, ax = plt.subplots(figsize=(7, 3))
+    fig.patch.set_alpha(0)
     ax.patch.set_alpha(0)
     _plot_macros(ax, pct, totals)
     _plot_calories(ax, kcal)

--- a/tests/test_plot.py
+++ b/tests/test_plot.py
@@ -17,6 +17,7 @@ def test_build_dashboard_figure():
     assert fig is not None
     assert totals['carb'] == approx(meal.totals['carb'])
     assert kcal == approx(meal.calories)
+    assert fig.patch.get_alpha() == 0
 
 def test_save_dashboard(tmp_path):
     meal = sample_meal()


### PR DESCRIPTION
## Summary
- set figure patch alpha to keep main dashboard transparent
- assert transparency in plot tests

## Testing
- `pip install -q -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6848e632af84833380071210fc896068